### PR TITLE
fix: replace deprecated numpy and plotly function

### DIFF
--- a/qcal/plotting/frequency.py
+++ b/qcal/plotting/frequency.py
@@ -50,7 +50,7 @@ def plot_freq_spectrum(
         #     'xanchor': 'center',
         #     'yanchor': 'top'
         # },
-        titlefont_size=25,
+        title=dict(font=dict(size=25)),
         showlegend=True,
         hovermode='closest',
         margin=dict(b=20,l=5,r=5,t=40),

--- a/qcal/sequence/utils.py
+++ b/qcal/sequence/utils.py
@@ -110,7 +110,7 @@ def compute_matrix_A(
                     integrand = g_n_hat * np.conj(g_m_hat)
                     
                     # Numerical integration (trapezoidal rule)
-                    integral_sum += weight * np.trapz(integrand.real, dx=df)
+                    integral_sum += weight * np.trapezoid(integrand.real, dx=df) 
             
             A[n, m] = integral_sum
     


### PR DESCRIPTION
Fix compatibility issues with newer package versions in qcal environment:
- plotting/frequency.py: Replace deprecated `titlefont_size` with
  `title=dict(font=dict(size=25))` for Plotly 5.x+
- sequence/utils.py: Replace `np.trapz()` with `np.trapezoid()` for
  NumPy 2.0+
These changes ensure the codebase works with both older and newer
versions of Plotly and NumPy.