### PR TITLE
Refines release workflow to prevent recursive triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
   release:
     name: Create release
     runs-on: ubuntu-latest
+    if: github.actor != 'github-actions[bot]'
     permissions:
       contents: write
 
@@ -106,7 +107,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md qcal/__init__.py
-          git commit -m "Release v${VERSION} [skip ci]"
+          git commit -m "Release v${VERSION}"
           git tag -a "v${VERSION}" -m "Release v${VERSION}"
           git push --follow-tags
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Remove [skip ci] and use the actor check instead
+
 ### Security
 
 ## [1.1.0] - 2026-04-24


### PR DESCRIPTION
Refines the release workflow to prevent recursive CI/CD triggers.

Removes the `[skip ci]` tag from release commits. Instead, the workflow now uses an actor check to ensure the release job only runs when not triggered by the `github-actions[bot]`. This prevents the release workflow from unnecessarily triggering itself or other pipelines after a release, which streamlines the CI/CD process.

Relates to #32